### PR TITLE
Hardcodes the docker-image being pulled for the excercise

### DIFF
--- a/_episodes/03-docker-for-cms-opendata.md
+++ b/_episodes/03-docker-for-cms-opendata.md
@@ -389,14 +389,14 @@ Then, download [the python container](https://gitlab.cern.ch/cms-cloud/python-vn
 If you are on native Linux and want to use X11-forwarding, use
 
 ~~~
-docker run -it --name my_python -P -p 8888:8888 --net=host --env="DISPLAY" -v $HOME/.Xauthority:/home/cmsusr/.Xauthority:rw -v ${HOME}/cms_open_data_python:/code gitlab-registry.cern.ch/cms-cloud/python-vnc:latest
+docker run -it --name my_python -P -p 8888:8888 --net=host --env="DISPLAY" -v $HOME/.Xauthority:/home/cmsusr/.Xauthority:rw -v ${HOME}/cms_open_data_python:/code gitlab-registry.cern.ch/cms-cloud/python-vnc:python3.10.5
 ~~~
 {: .language-bash}
 
 On MacOS and Windows WSL2 (and on native Linux if you do not want to use X11-forwarding), use
 
 ~~~
-docker run -it --name my_python -P -p 5901:5901 -p 6080:6080 -p 8888:8888 -v ${HOME}/cms_open_data_python:/code gitlab-registry.cern.ch/cms-cloud/python-vnc:latest
+docker run -it --name my_python -P -p 5901:5901 -p 6080:6080 -p 8888:8888 -v ${HOME}/cms_open_data_python:/code gitlab-registry.cern.ch/cms-cloud/python-vnc:python3.10.5
 ~~~
 {: .language-bash}
 


### PR DESCRIPTION
* The instructions had the `docker` command   that pulled the latest python image from the cms-gitlab registry
* `pip` in the `latest`  container  pulls  awkward 2.3.1 and already has uproot 5.0.10.
  *  this creates issues in the requested coffea 0.7.0 ( requires uproot4 and awkward 1.8.0 ) 

( context :  [Simplified Run 2 Analysis , Coffea Analysis](https://cms-opendata-workshop.github.io/workshop2023-lesson-ttbarljetsanalysis/03-coffea-analysis/index.html) , using the python container installed from [here](https://cms-opendata-workshop.github.io/workshop2023-lesson-docker/03-docker-for-cms-opendata/index.html) )